### PR TITLE
自動更新機能

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -4,7 +4,7 @@ $(function () {
     var image = message.image ? `<img class="lower-message__image" src="${message.image}">` : "";
 
     var html = `
-      <div class="message" data-id = ${message.id}>
+      <div class="message" data-message-id = ${message.id}>
         <div class="upper-message">
           <div class="upper-message__user-name">
             ${message.user_name}
@@ -47,4 +47,39 @@ $(function () {
       })
     return false;
   });
+
+  var reloadMessages = function () {
+    if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+      var last_message_id = $('.message:last').data("message-id");
+
+      var group_id = $('.main-header__left-box__current-group').data('group_id')
+      $.ajax({
+        url: `/groups/${group_id}/api/messages`,
+        type: 'get',
+        dataType: 'json',
+        data: { id: last_message_id }
+      })
+        .done(function (messages) {
+          if (messages.length !== 0) {
+            var insertHTML = '';
+            $.each(messages, function (i, message) {
+              insertHTML += buildHTML(message)
+            })
+            $('.messages').append(insertHTML);
+            $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight });
+          }
+        })
+        .fail(function () {
+          alert('error');
+        });
+    };
+  }
+  setInterval(reloadMessages, 7000);
+
+
 });
+
+
+
+
+

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_chat_main.html.haml
+++ b/app/views/messages/_chat_main.html.haml
@@ -1,7 +1,7 @@
 .chat-main
   .main-header
     .main-header__left-box
-      %h2.main-header__left-box__current-group 
+      %h2.main-header__left-box__current-group{"data-group_id": @group.id} 
         = @group.name
       %ul.main-header__left-box__member-list
         Member :&nbsp

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
 json.image @message.image.url
+json.id @message.id


### PR DESCRIPTION
#what
chatspaceに自動更新機能を追加した
自動更新機能を追加することでリロードをすることなく新規メッセージを取得することができる。自動更新機能を追加するに際には新たにルーティング、コントローラー、jbuilderを追加し対応するアクションなどを追加。
#why
自動更新機能はchatspaceでのコミュニケーションを円滑に進めるため。

https://i.gyazo.com/f9c5d0590445a98fd37419bc868a2bcf.mp4